### PR TITLE
Add a page for generating multi-source-map errors

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -23,6 +23,7 @@
     }
     newrelic.addReleaseId('multiverse', '<%= htmlWebpackPlugin.options.version %>')
     </script>
+    <script src="https://code.jquery.com/jquery-3.1.1.min.js"></script>
     <link rel="stylesheet" href="./global.css" />
   </head>
   <body>

--- a/app/js/app.js
+++ b/app/js/app.js
@@ -8,6 +8,7 @@ import { Ajax } from './components/ajax'
 import { Errors } from './components/errors'
 import { Slow } from './components/slow'
 import { Links } from './components/links'
+import { MoreErrors } from './components/more-errors'
 
 import promise from 'es6-promise'
 
@@ -51,6 +52,7 @@ const routes = (
       <IndexRoute component={Home} />
       <Route path="ajax" component={Ajax}/>
       <Route path="error" component={Errors}/>
+      <Route path="more-error" component={MoreErrors}/>
       <Route path="slow" component={Slow}/>
       <Route path="links" component={Links}/>
     </Route>

--- a/app/js/components/header.js
+++ b/app/js/components/header.js
@@ -10,6 +10,7 @@ export class Header extends Component {
           <li className='home'><Link to='/'>home</Link></li>
           <li className='ajax'><Link to='ajax' activeClassName='active'>Ajax</Link></li>
           <li className='error'><Link to='error' activeClassName='active'>Error</Link></li>
+          <li className='more-error'><Link to='more-error' activeClassName='active'>More Errors</Link></li>
           <li className='slow'><Link to='slow' activeClassName='active'>Slow</Link></li>
           <li className='links'><Link to='links' activeClassName='active'>Links</Link></li>
         </ul>

--- a/app/js/components/links.js
+++ b/app/js/components/links.js
@@ -19,6 +19,15 @@ export class Links extends Component {
         <ul>
           <li><a target='_blank' href='https://github.com/blainesch/synthetic-multiverse'>Repo</a></li>
         </ul>
+        <h3>Source Maps</h3>
+        <ul>
+          <li>
+            <a href='https://github.com/blainesch/synthetic-multiverse/blob/gh-pages/bundle.map.js'>Synthetic Multiverse source map</a>
+          </li>
+          <li>
+            <a href='https://code.jquery.com/jquery-3.1.1.min.map'>jQuery 3.1.1 source map</a>
+          </li>
+        </ul>
       </div>
     )
   }

--- a/app/js/components/more-errors.js
+++ b/app/js/components/more-errors.js
@@ -1,0 +1,15 @@
+import React, { Component } from 'react'
+
+// now with jQuery! for extra source-map fun.
+export class MoreErrors extends Component {
+  render() {
+    try {
+      $(function() {
+        throw new Error('jQueryWhoops!')
+      })
+    } catch (e) {
+      newrelic.noticeError(e)
+    }
+    return <span>We threw a jQuery-flavored error!</span>
+  }
+}

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "es6-promise": "^4.0.5",
+    "jquery": "^3.1.1",
     "react": "^15.3.2",
     "react-dom": "^15.3.2",
     "react-router": "^2.8.1"


### PR DESCRIPTION
I left the original errors alone so we could still see errors with only 1 source map if needed :) but now we'll have a way to see stack traces with multiple source maps!

To test, pull down this branch and test locally. You should see the error in the console. Or I can give you a demo.